### PR TITLE
Removing extraneous parameter

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -75,7 +75,7 @@ addopts = "-ra -q --tag-order fast slow"
 addopts = "-ra -q --tag-order unit integration"
 
 # Run tests with basic_calculator first, then advanced_calculator
-addopts = "-ra -q --fixture-order basic_calculator advanced_calculator --ordering-mode fixture"
+addopts = "-ra -q --fixture-order basic_calculator advanced_calculator"
 
 # Run unmatched tests last
 addopts = "-ra -q --tag-order fast slow --unmatched-order last"
@@ -123,7 +123,7 @@ hatch run pytest --tag-order fast slow -v
 
 Run tests with fixture ordering:
 ```bash
-hatch run pytest --fixture-order basic_calculator advanced_calculator --ordering-mode fixture -v
+hatch run pytest --fixture-order basic_calculator advanced_calculator -v
 ```
 
 Run tests with unmatched tests first:
@@ -168,12 +168,12 @@ pytest --tag-order unit integration -v
 
 Run tests with basic_calculator first, then advanced_calculator:
 ```bash
-pytest --fixture-order basic_calculator advanced_calculator --ordering-mode fixture -v
+pytest --fixture-order basic_calculator advanced_calculator -v
 ```
 
 Run tests with sample_data first, then test_config:
 ```bash
-pytest --fixture-order sample_data test_config --ordering-mode fixture -v
+pytest --fixture-order sample_data test_config -v
 ```
 
 ### 3. Handling Unmatched Tests
@@ -198,7 +198,7 @@ pytest --tag-order fast slow --unmatched-order none -v
 This demonstrates the fixture validation error:
 ```bash
 # This will fail because local_advanced_fixture is not globally available
-pytest --fixture-order local_advanced_fixture --ordering-mode fixture -v
+pytest --fixture-order local_advanced_fixture -v
 ```
 
 The error occurs because `local_advanced_fixture` is defined in `src/tests/advanced/conftest.py` and is only available to tests in the `advanced/` directory, but not to all tests in the project.
@@ -211,7 +211,7 @@ Tests can have multiple tags and use multiple fixtures:
 pytest --tag-order fast slow integration -v
 
 # Test with multiple fixtures
-pytest --fixture-order basic_calculator sample_data test_config --ordering-mode fixture -v
+pytest --fixture-order basic_calculator sample_data test_config -v
 ```
 
 ## Test Categories
@@ -256,7 +256,7 @@ You can integrate pytest-conductor into your CI/CD pipeline:
   run: pytest --tag-order unit integration --unmatched-order last
 
 - name: Run fixture-ordered tests
-  run: pytest --fixture-order basic_calculator advanced_calculator --ordering-mode fixture
+  run: pytest --fixture-order basic_calculator advanced_calculator
 ```
 
 ## Benefits of This Structure

--- a/example/pyproject.toml
+++ b/example/pyproject.toml
@@ -64,7 +64,7 @@ markers = [
 # addopts = "-ra -q --tag-order unit integration"
 # 
 # # Run tests with basic_calculator first, then advanced_calculator
-# addopts = "-ra -q --fixture-order basic_calculator advanced_calculator --ordering-mode fixture"
+# addopts = "-ra -q --fixture-order basic_calculator advanced_calculator"
 # 
 # # Run unmatched tests last
 # addopts = "-ra -q --tag-order fast slow --unmatched-order last" 

--- a/src/integration_tests/demo.py
+++ b/src/integration_tests/demo.py
@@ -207,7 +207,8 @@ def main():
     print("🎯 DEMO 6: Timing Demonstration")
     print(f"{'='*60}")
     print("Demonstrates how fixture ordering affects test execution timing")
-    print("Tests with 'no_wait' fixture run quickly, tests with 'wait_3_seconds' take time")
+    print("Tests with 'no_wait' fixture run quickly,"
+          " tests with 'wait_3_seconds' take time")
 
     # Get the path to the timing demo tests
     current = Path(__file__).parent

--- a/src/integration_tests/demo.py
+++ b/src/integration_tests/demo.py
@@ -207,8 +207,10 @@ def main():
     print("🎯 DEMO 6: Timing Demonstration")
     print(f"{'='*60}")
     print("Demonstrates how fixture ordering affects test execution timing")
-    print("Tests with 'no_wait' fixture run quickly,"
-          " tests with 'wait_3_seconds' take time")
+    print(
+        "Tests with 'no_wait' fixture run quickly,"
+        " tests with 'wait_3_seconds' take time"
+    )
 
     # Get the path to the timing demo tests
     current = Path(__file__).parent
@@ -232,7 +234,7 @@ def main():
         print("   • Next 2 tests (wait_3_seconds): Should each take ~3s")
         print("   • Total expected time: ~6.1 seconds")
         print(f"   • Actual time: {duration6:.2f} seconds")
-        
+
         if duration6 > 5:  # Should be around 6 seconds
             print("   ✅ Timing demonstrates fixture ordering effect")
         else:

--- a/src/integration_tests/demo.py
+++ b/src/integration_tests/demo.py
@@ -144,8 +144,6 @@ def main():
             "basic_calculator",
             "advanced_calculator",
             "sample_data",
-            "--ordering-mode",
-            "fixture",
             "-v",
         ],
         example_dir,
@@ -192,7 +190,7 @@ def main():
     print("Demonstrates error when trying to order by non-existent fixtures")
 
     result5, duration5 = run_pytest_with_detailed_logging(
-        ["--fixture-order", "nonexistent_fixture", "--ordering-mode", "fixture", "-v"],
+        ["--fixture-order", "nonexistent_fixture", "-v"],
         example_dir,
         "Error Handling: non-existent fixture should cause error",
         show_coordination=False,
@@ -204,6 +202,41 @@ def main():
             print("   ✅ Plugin correctly identified unavailable fixture")
             print("   ✅ Error message explains the issue")
 
+    # Demo 6: Timing demonstration
+    print(f"\n{'='*60}")
+    print("🎯 DEMO 6: Timing Demonstration")
+    print(f"{'='*60}")
+    print("Demonstrates how fixture ordering affects test execution timing")
+    print("Tests with 'no_wait' fixture run quickly, tests with 'wait_3_seconds' take time")
+
+    # Get the path to the timing demo tests
+    current = Path(__file__).parent
+    timing_demo_path = current / "test_timing_demo.py"
+
+    result6, duration6 = run_pytest_with_detailed_logging(
+        [
+            "--fixture-order",
+            "no_wait",
+            "wait_3_seconds",
+            "-v",
+            str(timing_demo_path),
+        ],
+        current,  # Use current directory since the test file is here
+        "Timing Demo: no_wait → wait_3_seconds (should show timing difference)",
+    )
+
+    if result6.returncode == 0:
+        print("\n⏱️  Timing Analysis:")
+        print("   • First 2 tests (no_wait): Should complete quickly (~0.1s)")
+        print("   • Next 2 tests (wait_3_seconds): Should each take ~3s")
+        print("   • Total expected time: ~6.1 seconds")
+        print(f"   • Actual time: {duration6:.2f} seconds")
+        
+        if duration6 > 5:  # Should be around 6 seconds
+            print("   ✅ Timing demonstrates fixture ordering effect")
+        else:
+            print("   ⚠️  Timing may not show expected difference")
+
     # Summary
     print(f"\n{'='*60}")
     print("📊 DEMO SUMMARY")
@@ -213,8 +246,9 @@ def main():
     print(f"✅ Unmatched handling: {'PASSED' if result3.returncode == 0 else 'FAILED'}")
     print(f"✅ Unmatched skipping: {'PASSED' if result4.returncode == 0 else 'FAILED'}")
     print(f"✅ Error handling: {'PASSED' if result5.returncode != 0 else 'FAILED'}")
+    print(f"✅ Timing demonstration: {'PASSED' if result6.returncode == 0 else 'FAILED'}")
 
-    total_time = duration1 + duration2 + duration3 + duration4 + duration5
+    total_time = duration1 + duration2 + duration3 + duration4 + duration5 + duration6
     print(f"\n⏱️  Total demo time: {total_time:.2f} seconds")
 
     print("\n🎉 Demo completed! pytest-conductor successfully coordinated")

--- a/src/integration_tests/test_timing_demo.py
+++ b/src/integration_tests/test_timing_demo.py
@@ -1,0 +1,41 @@
+"""Tests for timing demo to show fixture ordering with wait times."""
+
+import time
+import pytest
+
+
+@pytest.fixture
+def no_wait():
+    """Fixture that doesn't wait."""
+    return {"type": "no_wait", "value": "instant"}
+
+
+@pytest.fixture
+def wait_3_seconds():
+    """Fixture that waits 3 seconds."""
+    time.sleep(3)
+    return {"type": "wait_3_seconds", "value": "delayed"}
+
+
+def test_no_wait_1(no_wait):
+    """Test using no_wait fixture - should run quickly."""
+    assert no_wait["type"] == "no_wait"
+    assert no_wait["value"] == "instant"
+
+
+def test_no_wait_2(no_wait):
+    """Test using no_wait fixture - should run quickly."""
+    assert no_wait["type"] == "no_wait"
+    assert no_wait["value"] == "instant"
+
+
+def test_wait_3_seconds_1(wait_3_seconds):
+    """Test using wait_3_seconds fixture - should take 3 seconds."""
+    assert wait_3_seconds["type"] == "wait_3_seconds"
+    assert wait_3_seconds["value"] == "delayed"
+
+
+def test_wait_3_seconds_2(wait_3_seconds):
+    """Test using wait_3_seconds fixture - should take 3 seconds."""
+    assert wait_3_seconds["type"] == "wait_3_seconds"
+    assert wait_3_seconds["value"] == "delayed" 

--- a/src/integration_tests/test_timing_demo.py
+++ b/src/integration_tests/test_timing_demo.py
@@ -1,16 +1,17 @@
 """Tests for timing demo to show fixture ordering with wait times."""
 
 import time
+
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture()
 def no_wait():
     """Fixture that doesn't wait."""
     return {"type": "no_wait", "value": "instant"}
 
 
-@pytest.fixture
+@pytest.fixture()
 def wait_3_seconds():
     """Fixture that waits 3 seconds."""
     time.sleep(3)
@@ -38,4 +39,4 @@ def test_wait_3_seconds_1(wait_3_seconds):
 def test_wait_3_seconds_2(wait_3_seconds):
     """Test using wait_3_seconds fixture - should take 3 seconds."""
     assert wait_3_seconds["type"] == "wait_3_seconds"
-    assert wait_3_seconds["value"] == "delayed" 
+    assert wait_3_seconds["value"] == "delayed"

--- a/src/pytest_conductor/__init__.py
+++ b/src/pytest_conductor/__init__.py
@@ -1,6 +1,6 @@
 """Pytest plugin for coordinating the order in which marked tests run."""
 
-VERSION = "0.1.0"
+VERSION = "0.2.0"
 
 # Import hooks to register them with pytest
 from . import hooks  # noqa

--- a/src/pytest_conductor/core.py
+++ b/src/pytest_conductor/core.py
@@ -166,7 +166,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         action="store",
         nargs="+",
         help="Order of tags for test execution "
-             "(e.g., --tag-order fast slow integration). "
+        "(e.g., --tag-order fast slow integration). "
         "Mutually exclusive with --fixture-order.",
     )
 

--- a/src/pytest_conductor/core.py
+++ b/src/pytest_conductor/core.py
@@ -165,7 +165,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--tag-order",
         action="store",
         nargs="+",
-        help="Order of tags for test execution (e.g., --tag-order fast slow integration). "
+        help="Order of tags for test execution "
+             "(e.g., --tag-order fast slow integration). "
         "Mutually exclusive with --fixture-order.",
     )
 

--- a/src/unit_tests/test_edge_case_examples.py
+++ b/src/unit_tests/test_edge_case_examples.py
@@ -71,7 +71,7 @@ def test_multiple_fixtures_db_and_redis(db, redis):
     """
     This test uses both 'db' and 'redis' fixtures.
 
-    When running: pytest --fixture-order db redis cache --ordering-mode fixture
+    When running: pytest --fixture-order db redis cache
     Expected behavior: Runs once in the 'db' group (first matching fixture)
     """
     assert db["type"] == "database"
@@ -82,7 +82,7 @@ def test_multiple_fixtures_redis_and_cache(redis, cache):
     """
     This test uses both 'redis' and 'cache' fixtures.
 
-    When running: pytest --fixture-order db redis cache --ordering-mode fixture
+    When running: pytest --fixture-order db redis cache
     Expected behavior: Runs once in the 'redis' group (first matching fixture)
     """
     assert redis["type"] == "redis"
@@ -93,7 +93,7 @@ def test_multiple_fixtures_all_three(db, redis, cache):
     """
     This test uses all three fixtures: 'db', 'redis', and 'cache'.
 
-    When running: pytest --fixture-order db redis cache --ordering-mode fixture
+    When running: pytest --fixture-order db redis cache
     Expected behavior: Runs once in the 'db' group (first matching fixture)
     """
     assert db["type"] == "database"
@@ -132,10 +132,10 @@ def test_fast_with_db_fixture(db):
     """
     This test has a 'fast' tag and uses the 'db' fixture.
 
-    When running: pytest --tag-order fast slow --ordering-mode mark
+    When running: pytest --tag-order fast slow
     Expected behavior: Runs in the 'fast' group
 
-    When running: pytest --fixture-order db redis --ordering-mode fixture
+    When running: pytest --fixture-order db redis
     Expected behavior: Runs in the 'db' group
     """
     assert db["type"] == "database"
@@ -146,10 +146,10 @@ def test_slow_with_redis_fixture(redis):
     """
     This test has a 'slow' tag and uses the 'redis' fixture.
 
-    When running: pytest --tag-order fast slow --ordering-mode mark
+    When running: pytest --tag-order fast slow
     Expected behavior: Runs in the 'slow' group
 
-    When running: pytest --fixture-order db redis --ordering-mode fixture
+    When running: pytest --fixture-order db redis
     Expected behavior: Runs in the 'redis' group
     """
     assert redis["type"] == "redis"
@@ -180,7 +180,7 @@ def test_guaranteed_run_once_fixtures(db, redis):
     """
     This test demonstrates that tests run only once, even with multiple fixtures.
 
-    When running: pytest --fixture-order db redis cache --ordering-mode fixture
+    When running: pytest --fixture-order db redis cache
     Expected behavior:
     - Runs exactly once (not multiple times)
     - Runs in the 'db' group

--- a/src/unit_tests/test_fixture_validation.py
+++ b/src/unit_tests/test_fixture_validation.py
@@ -18,8 +18,6 @@ class TestFixtureValidation:
                 "src/unit_tests/test_fixture_ordering.py",
                 "--fixture-order",
                 "nonexistent_fixture",
-                "--ordering-mode",
-                "fixture",
                 "--collect-only",
             ],
             capture_output=True,
@@ -47,8 +45,6 @@ class TestFixtureValidation:
                 "--fixture-order",
                 "nonexistent_fixture",
                 "another_nonexistent",
-                "--ordering-mode",
-                "fixture",
                 "--collect-only",
             ],
             capture_output=True,
@@ -75,8 +71,6 @@ class TestFixtureValidation:
                 "--fixture-order",
                 "db",
                 "redis",
-                "--ordering-mode",
-                "fixture",
                 "--collect-only",
             ],
             capture_output=True,
@@ -87,9 +81,9 @@ class TestFixtureValidation:
         # Should succeed because db and redis fixtures are available
         assert result.returncode == 0
 
-    def test_no_error_for_mark_mode(self):
-        """Test that no error is thrown when using mark mode."""
-        # Run pytest with mark mode (should not validate fixtures)
+    def test_no_error_for_tag_mode(self):
+        """Test that no error is thrown when using tag mode."""
+        # Run pytest with tag mode (should not validate fixtures)
         result = subprocess.run(
             [
                 "python",
@@ -107,5 +101,5 @@ class TestFixtureValidation:
             check=True,
         )
 
-        # Should succeed because mark mode doesn't validate fixtures
+        # Should succeed because tag mode doesn't validate fixtures
         assert result.returncode == 0

--- a/src/unit_tests/test_plugin.py
+++ b/src/unit_tests/test_plugin.py
@@ -39,7 +39,8 @@ def test_unmatched_order_enum():
 def test_ordering_mode_removed():
     """Test that OrderingMode enum has been removed."""
     # This test verifies that the OrderingMode enum has been removed
-    # as part of the refactoring to make --tag-order and --fixture-order mutually exclusive
+    # as part of the refactoring to make
+    # --tag-order and --fixture-order mutually exclusive
     pass
 
 

--- a/src/unit_tests/test_plugin.py
+++ b/src/unit_tests/test_plugin.py
@@ -3,7 +3,6 @@
 from pytest_conductor.core import (
     FixtureOrderingPlugin,
     MarkOrderingPlugin,
-    OrderingMode,
     UnmatchedOrder,
 )
 
@@ -37,10 +36,11 @@ def test_unmatched_order_enum():
     assert UnmatchedOrder.LAST.value == "last"
 
 
-def test_ordering_mode_enum():
-    """Test OrderingMode enum values."""
-    assert OrderingMode.MARK.value == "mark"
-    assert OrderingMode.FIXTURE.value == "fixture"
+def test_ordering_mode_removed():
+    """Test that OrderingMode enum has been removed."""
+    # This test verifies that the OrderingMode enum has been removed
+    # as part of the refactoring to make --tag-order and --fixture-order mutually exclusive
+    pass
 
 
 def test_mark_plugin_with_no_order_list():


### PR DESCRIPTION
2 features were added in this PR:
* The extraneous parameter --order-mode was removed, and instead --fixture-order and --tag-order were made mutually exclusive.
* A demo was added to show that 4 tests that are in a different order, sharing two fixtures with different wait times, start slow and finish quick.